### PR TITLE
[Quick Fix] NPC owner where changed at ship selection in universe editor

### DIFF
--- a/Source/X_Rebirth_Save_Game_Editor/DataStructure/ShipData.cs
+++ b/Source/X_Rebirth_Save_Game_Editor/DataStructure/ShipData.cs
@@ -853,7 +853,7 @@ namespace X_Rebirth_Save_Game_Editor.DataStructure
                     npcs = new List<NPCData>();
 
                     // Get All NPCs on ship
-                    foreach (XmlNode node in ShipNode.SelectNodes("//component[@class='npc']"))
+                    foreach (XmlNode node in ShipNode.SelectNodes(".//component[@class='npc']"))
                     {
                         npcs.Add(new NPCData(node.ParentNode, cde));
                     }

--- a/Source/X_Rebirth_Save_Game_Editor/DataStructure/ShipStorageData.cs
+++ b/Source/X_Rebirth_Save_Game_Editor/DataStructure/ShipStorageData.cs
@@ -40,7 +40,7 @@ namespace X_Rebirth_Save_Game_Editor.DataStructure
                 if (string.IsNullOrEmpty(ware))  { throw new Exception("ware must contain a value");  }
                 if (amount <= 0) { throw new Exception("amount must be greather than 0"); }
 
-                XmlNode summarydNode = ShipStorageNode.FirstChild.FirstChild.FirstChild;
+                XmlNode summarydNode = ShipStorageNode.SelectSingleNode(".//summary");
                 XmlNode newItemNode = null;
 
                 try

--- a/Source/X_Rebirth_Save_Game_Editor/DataStructure/ShipStorageData.cs
+++ b/Source/X_Rebirth_Save_Game_Editor/DataStructure/ShipStorageData.cs
@@ -40,17 +40,31 @@ namespace X_Rebirth_Save_Game_Editor.DataStructure
                 if (string.IsNullOrEmpty(ware))  { throw new Exception("ware must contain a value");  }
                 if (amount <= 0) { throw new Exception("amount must be greather than 0"); }
 
-                XmlNode summarydNode = ShipStorageNode.SelectSingleNode(".//summary");
+                XmlNode summaryNode = ShipStorageNode.SelectSingleNode(".//summary");
                 XmlNode newItemNode = null;
+                if (summaryNode == null)
+                {
+                    XmlElement cargodNode = ShipStorageNode.OwnerDocument.CreateElement("cargo", "");
+                    ShipStorageNode.SelectSingleNode(".//component[@class='storage']").PrependChild(cargodNode);
+
+                    summaryNode = ShipStorageNode.OwnerDocument.CreateNode(XmlNodeType.Element, "summary", "");
+                    summaryNode.Attributes.Append(ShipStorageNode.OwnerDocument.CreateAttribute("state"));
+                    summaryNode.Attributes.Append(ShipStorageNode.OwnerDocument.CreateAttribute("parent"));
+                    summaryNode.Attributes.Append(ShipStorageNode.OwnerDocument.CreateAttribute("connection"));
+                    summaryNode.Attributes["state"].Value = "collapsed";
+                    summaryNode.Attributes["parent"].Value = ShipStorageNode.SelectSingleNode(".//component[@class='storage']").Attributes["id"].Value;
+                    summaryNode.Attributes["connection"].Value = "cargo";
+                    cargodNode.PrependChild(summaryNode);
+                }
 
                 try
                 {
-                    newItemNode = summarydNode.OwnerDocument.CreateNode(XmlNodeType.Element, "ware", "");
-                    newItemNode.Attributes.Append(summarydNode.OwnerDocument.CreateAttribute("ware"));
+                    newItemNode = summaryNode.OwnerDocument.CreateNode(XmlNodeType.Element, "ware", "");
+                    newItemNode.Attributes.Append(summaryNode.OwnerDocument.CreateAttribute("ware"));
                     newItemNode.Attributes["ware"].Value = ware;
                     if (amount > 1)
                     {
-                        newItemNode.Attributes.Append(summarydNode.OwnerDocument.CreateAttribute("amount"));
+                        newItemNode.Attributes.Append(summaryNode.OwnerDocument.CreateAttribute("amount"));
                         newItemNode.Attributes["amount"].Value = amount.ToString();
                     }
                 }
@@ -61,7 +75,7 @@ namespace X_Rebirth_Save_Game_Editor.DataStructure
 
                 try
                 {
-                    summarydNode.AppendChild(newItemNode);
+                    summaryNode.AppendChild(newItemNode);
                     ShipStorageItems.Add(new ShipStorageItemData(newItemNode, cde));
                 }
                 catch (Exception ex)

--- a/Source/X_Rebirth_Save_Game_Editor/DataStructure/ShipStorageData.cs
+++ b/Source/X_Rebirth_Save_Game_Editor/DataStructure/ShipStorageData.cs
@@ -118,7 +118,7 @@ namespace X_Rebirth_Save_Game_Editor.DataStructure
                     try
                     {
                         ShipStorageItems = new List<ShipStorageItemData>();
-                        foreach (XmlNode node in ShipStorageNode.FirstChild.FirstChild.FirstChild.ChildNodes)
+                        foreach (XmlNode node in ShipStorageNode.SelectNodes(".//ware"))
                         {
                             ShipStorageItems.Add(new ShipStorageItemData(node, cde));
                         }

--- a/Source/X_Rebirth_Save_Game_Editor/FormShipEditorInfo.Designer.cs
+++ b/Source/X_Rebirth_Save_Game_Editor/FormShipEditorInfo.Designer.cs
@@ -107,6 +107,7 @@
             this.toolTip1.SetToolTip(this.comboBoxShipOwner, "The owner for the ship and it\'s crew is set.\r\nPlease let me know if there are sit" +
         "uations that do not work when changing ownership.");
             this.comboBoxShipOwner.SelectedIndexChanged += new System.EventHandler(this.comboBoxShipOwner_SelectedIndexChanged);
+            this.comboBoxShipOwner.SelectionChangeCommitted += new System.EventHandler(this.comboBoxShipOwner_SelectedIndexCommitted);
             // 
             // labelShipOwner
             // 

--- a/Source/X_Rebirth_Save_Game_Editor/FormShipEditorInfo.cs
+++ b/Source/X_Rebirth_Save_Game_Editor/FormShipEditorInfo.cs
@@ -85,6 +85,11 @@ namespace X_Rebirth_Save_Game_Editor
 
         private void comboBoxShipOwner_SelectedIndexChanged(object sender, EventArgs e)
         {
+            //Ship.ShipOwner = comboBoxShipOwner.SelectedItem.ToString();
+        }
+
+        private void comboBoxShipOwner_SelectedIndexCommitted(object sender, EventArgs e)
+        {
             Ship.ShipOwner = comboBoxShipOwner.SelectedItem.ToString();
         }
     }


### PR DESCRIPTION
The event for combobox "owner" of _FormShipEditorInfo_ has been changed from `SelectedIndexChanged` type to `SelectedIndexCommitted` to temporary solve the issue #7.